### PR TITLE
Catkinize the library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.5)
 project(iris_lama VERSION 1.0 LANGUAGES CXX C)
 
+# http://answers.ros.org/question/230877/optionally-build-a-package-with-catkin/
+if( CATKIN_DEVEL_PREFIX OR catkin_FOUND OR CATKIN_BUILD_BINARY_PACKAGE)
+    set(COMPILING_WITH_CATKIN 1)
+endif()
+
 set(CMAKE_CXX_STANDARD 11) # use c++11
 
 find_package(Eigen 3 QUIET)
@@ -8,18 +13,25 @@ if(NOT Eigen_FOUND)
   include(${PROJECT_SOURCE_DIR}/cmake/FindEigen3.cmake)
   set(Eigen_INCLUDE_DIR "${EIGEN3_INCLUDE_DIR}")
 endif()
-include_directories(${Eigen_INCLUDE_DIR})
 
 # Default to release mode.
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
+if(COMPILING_WITH_CATKIN)
+    message(STATUS "----------------")
+    message(STATUS "Catkin detected")
+    message(STATUS "----------------")
 
+    find_package(catkin REQUIRED)
+    catkin_package(
+        INCLUDE_DIRS include
+        LIBRARIES ${PROJECT_NAME}
+        )
+endif()
+
+INCLUDE_DIRECTORIES( include ${Eigen_INCLUDE_DIR} ${catkin_INCLUDE_DIRS} )
 add_subdirectory(src)
 
-export(TARGETS iris-lama FILE iris_lamaConfig.cmake)
-
-set(CMAKE_EXPORT_PACKAGE_REGISTRY ON)
-export(PACKAGE iris_lama)
 

--- a/package.xml
+++ b/package.xml
@@ -16,7 +16,7 @@
 
     <license>BSD</license>
 
-    <buildtool_depend>cmake</buildtool_depend>
+    <buildtool_depend>catkin</buildtool_depend>
 
     <build_depend>eigen</build_depend>
     <run_depend>eigen</run_depend>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,10 +51,25 @@ set(lama_SOURCES
     pf_slam2d.cpp
 )
 
-add_library(iris-lama STATIC ${lama_SOURCES})
+add_library(${PROJECT_NAME} ${lama_SOURCES})
+target_compile_options(${PROJECT_NAME} PRIVATE -Wall)
 
-target_include_directories(iris-lama PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
-target_compile_options(iris-lama PRIVATE -Wall)
+
+if(COMPILING_WITH_CATKIN)
+    install(TARGETS ${PROJECT_NAME}
+      ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+      LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+      RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+    )
+    install(DIRECTORY include/lama/
+      DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+      PATTERN ".svn" EXCLUDE
+    )
+else()
+    export(TARGETS ${PROJECT_NAME} FILE iris_lamaConfig.cmake)
+    set(CMAKE_EXPORT_PACKAGE_REGISTRY ON)
+    export(PACKAGE iris_lama)
+endif()
 
 


### PR DESCRIPTION
This PR address a concern that I have and was mentioned in #13.

iris_lama haven't published yet a binary for ROS. This means that people need to compile it from source to test it.

I think one of the limitations to do that is that **iris_lama** must be correctly "catkinized". At the same time, I agree with you in keeping this library ROS independent.

I had to face the same problem with [BehaviorTree.CPP](https://github.com/BehaviorTree/BehaviorTree.CPP).

In this PR you can find a little trick to to detect catkin in cmake.

Note that if you decide to merge this PR, I will need to also update accordingly **iris_lama_ros**.

