### PR TITLE
Fix infinite loop when performing global localization

### DIFF
--- a/src/loc2d.cpp
+++ b/src/loc2d.cpp
@@ -161,6 +161,7 @@ void lama::Loc2D::globalLocalization(const PointCloudXYZ::Ptr& surface)
                 continue;
 
             a = random::uniform() * 2 * M_PI - M_PI;
+            break;
         }
 
         Pose2D p(x, y , a);


### PR DESCRIPTION
That's basically it; the code was missing a break when searching for candidate positions on the map.