### PR TITLE
[feature/slam2d] Add the option to mark no-hits as free space

### DIFF
--- a/include/lama/pf_slam2d.h
+++ b/include/lama/pf_slam2d.h
@@ -156,6 +156,9 @@ public:
         double l2_max = 0.5;
         /// If != from zero, truncate the ray lenght (includes the endpoint).
         double truncated_ray = 0.0;
+        /// If != from zero and ray length > truncated_range, truncate the ray from the
+        /// starting point and do not add an obstacle for the hit
+        double truncated_range = 0.0;
         /// Resolutions of the maps.
         double resolution = 0.05;
         /// The side size of a patch
@@ -261,6 +264,7 @@ private:
     bool   has_first_scan;
 
     double truncated_ray_;
+    double truncated_range_;
     double max_weight_;
     double delta_free_;
     double neff_;

--- a/include/lama/slam2d.h
+++ b/include/lama/slam2d.h
@@ -101,6 +101,9 @@ public:
         double l2_max = 0.5;
         /// If != from zero, truncate the ray lenght (includes the endpoint).
         double truncated_ray = 0.0;
+        /// If != from zero and ray length > truncated_range, truncate the ray from the
+        /// starting point and do not add an obstacle for the hit
+        double truncated_range = 0.0;
         /// Resolutions of the maps.
         double resolution = 0.05;
         /// The side size of a patch.
@@ -177,6 +180,7 @@ private:
 
     uint32_t number_of_proccessed_cells_;
     double truncated_ray_;
+    double truncated_range_;
 };
 
 } /* lama */


### PR DESCRIPTION
### Why
Avoid the cone effect in places such as corridors when the scan does not hit anything.

### Summary
Instead of completely ignoring a no-hit while mapping, the algorithm can now mark the cells as free-space.

### Example
The images below illustrate the difference in behavior.
#### Before
![image](https://user-images.githubusercontent.com/5129986/100860600-fed15a00-3490-11eb-9d9f-436d0cdeaa4b.png)
#### After
![image](https://user-images.githubusercontent.com/5129986/100860718-27595400-3491-11eb-92bd-181da120d20c.png)