### PR TITLE
build: install package.xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,3 +51,6 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}ConfigVersion.cmake
   DESTINATION ${ConfigPackageLocation})
 
+install(FILES
+  ${CMAKE_SOURCE_DIR}/package.xml
+  DESTINATION ${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME})


### PR DESCRIPTION
Installs the `package.xml` to the `share` folder in the `install` space so that the package can be resolved by [rosdep](https://wiki.ros.org/rosdep).